### PR TITLE
Fix for Tinkerpop 3.3.0

### DIFF
--- a/gremlin-haskell.cabal
+++ b/gremlin-haskell.cabal
@@ -17,6 +17,7 @@ library
   exposed-modules:     Database.TinkerPop
                        Database.TinkerPop.Types
                        Database.TinkerPop.Internal
+  other-modules:       Database.TinkerPop.Internal.GraphSON
   ghc-options:   -Wall -fwarn-tabs
   default-extensions:  OverloadedStrings
                        QuasiQuotes

--- a/src/Database/TinkerPop.hs
+++ b/src/Database/TinkerPop.hs
@@ -29,7 +29,7 @@ import Control.Lens
 -- | Connect to Gremlin Server
 run :: String -> Int -> (Connection -> IO ()) -> IO ()
 run host port app = do
-    handle (wsExceptionHandler "main thread") $ WS.runClient host port "/" $ \ws -> do
+    handle (wsExceptionHandler "main thread") $ WS.runClient host port "/gremlin" $ \ws -> do
         done <- MV.newEmptyMVar
         cs <- S.newTVarIO M.empty
         let conn = Connection ws cs

--- a/src/Database/TinkerPop/Internal.hs
+++ b/src/Database/TinkerPop/Internal.hs
@@ -37,12 +37,14 @@ handler conn done = do
 
 -- | Handle exception from websocket.
 --
--- Ignore ConnectionClised exception that expected.
+-- Ignore ConnectionClosed and CloseRequest (status 1000) exceptions
+-- that expected.
 wsExceptionHandler :: Text -> SomeException -> IO ()
 wsExceptionHandler label e = do
     -- putStrLn $ "handle exception[" `append` label `append` "]: " `append` (pack $ show e)
     case fromException e of
      Just WS.ConnectionClosed -> return ()
+     Just (WS.CloseRequest 1000 _) -> return ()
      _ -> do
          putStrLn $ "unexpect exception[" `append` label `append` "]: " `append` (pack $ show e)
          throw e

--- a/src/Database/TinkerPop/Internal/GraphSON.hs
+++ b/src/Database/TinkerPop/Internal/GraphSON.hs
@@ -9,7 +9,6 @@ module Database.TinkerPop.Internal.GraphSON
        ( GraphSON(..)
        ) where
 
-import Control.Monad (guard)
 import Data.Aeson (ToJSON(..), FromJSON(..), object, (.=), Value(..), (.:?))
 import Data.Aeson.Types (Parser)
 import Data.Text (Text)
@@ -32,10 +31,12 @@ instance ToJSON a => ToJSON (GraphSON a) where
 
 instance FromJSON a => FromJSON (GraphSON a) where
   parseJSON v@(Object o) = do
-    guard (length o == 2)
-    mtype <- o .:? "@type"
-    mvalue <- o .:? "@value"
-    maybe (parseDirect v) return $ typedGraphSON <$> mtype <*> mvalue
+    if length o /= 2
+      then parseDirect v
+      else do
+      mtype <- o .:? "@type"
+      mvalue <- o .:? "@value"
+      maybe (parseDirect v) return $ typedGraphSON <$> mtype <*> mvalue
   parseJSON v = parseDirect v
     
 typedGraphSON :: Text -> a -> GraphSON a

--- a/src/Database/TinkerPop/Internal/GraphSON.hs
+++ b/src/Database/TinkerPop/Internal/GraphSON.hs
@@ -1,0 +1,45 @@
+-- |
+-- Module: Database.TinkerPop.Internal.GraphSON
+-- Copyright: (c) 2017 The gremlin-haskell Authors
+-- Description: Internal helper for encoding/decoding GraphSON
+-- Maintainer: Toshio Ito <debug.ito@gmail.com>
+--
+-- 
+module Database.TinkerPop.Internal.GraphSON
+       ( GraphSON(..)
+       ) where
+
+import Control.Monad (guard)
+import Data.Aeson (ToJSON(..), FromJSON(..), object, (.=), Value(..), (.:?))
+import Data.Aeson.Types (Parser)
+import Data.Text (Text)
+
+-- | Wrapper for the typed JSON object introduced in GraphSON 2. If
+-- '_atType' is 'Just', it is a typed JSON object with the given type
+-- text. If '_atType' is 'Nothing', the bare value of type @a@ is
+-- encoded to/decoded from JSON.
+data GraphSON a = GraphSON {
+  _atType :: Maybe Text
+  , _atValue :: a
+  } deriving (Show,Eq,Ord)
+
+instance ToJSON a => ToJSON (GraphSON a) where
+  toJSON gson = case _atType gson of
+    Nothing -> toJSON $ _atValue gson
+    Just t -> object [ "@type" .= t,
+                       "@value" .= (_atValue gson)
+                     ]
+
+instance FromJSON a => FromJSON (GraphSON a) where
+  parseJSON v@(Object o) = do
+    guard (length o == 2)
+    mtype <- o .:? "@type"
+    mvalue <- o .:? "@value"
+    maybe (parseDirect v) return $ typedGraphSON <$> mtype <*> mvalue
+  parseJSON v = parseDirect v
+    
+typedGraphSON :: Text -> a -> GraphSON a
+typedGraphSON t v = GraphSON (Just t) v
+
+parseDirect :: FromJSON a => Value -> Parser (GraphSON a)
+parseDirect v = GraphSON Nothing <$> parseJSON v


### PR DESCRIPTION
Fix for TinkerPop-3.3.0 Gremlin Server. These changes are backward-compatible, so you don't have to bump major or minor version number.

- Fix WebSocket endpoint from "/" -> "/gremlin". This should fix #3.
- Handle `CloseRequest` exception, which is completely normal if status code is 1000. This should fix #2.
- Now `ResponseResult` accepts GraphSON 3.0 format, which is the default serializer of TinkerPop 3.3.0 Gremlin server.

I confirmed this passed the test with TinkerPop 3.1.0-incubating, 3.2.6 and 3.3.0.
